### PR TITLE
Compile the x64 version first

### DIFF
--- a/Platform.js
+++ b/Platform.js
@@ -132,7 +132,7 @@ function findMSVCNativeToolCommand() {
 
 class WinPlatform extends Platform {
     constructor(debug, verbose) {
-        super("win", ["x86", "x64"], debug, verbose);
+        super("win", ["x64", "x86"], debug, verbose);
         let msvcTool = findMSVCNativeToolCommand();
         let buildToolPath = childProcess.execSync("\"" + msvcTool + "\"").toString();
         let lines = buildToolPath.split("\r\n");


### PR DESCRIPTION
Compile the x64 version first to prevent the 64-bit compiler from being unavailable in the script