### PR TITLE
Pass archs aruments to cmd when buildWithScript

### DIFF
--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -233,7 +233,7 @@ function getHash(content) {
     return hash.digest('hex')
 }
 
-function exec(cmd, dir, verbose, printCmd) {
+function exec(cmd, dir, verbose, printCmd, args) {
     if (!dir) {
         dir = process.cwd();
     } else {
@@ -258,7 +258,7 @@ function exec(cmd, dir, verbose, printCmd) {
     if (printCmd) {
         log(cmd);
     }
-    let result = childProcess.spawnSync(cmd, options);
+    let result = childProcess.spawnSync(cmd, args, options);
     if (result.status !== 0) {
         if (!verbose) {
             log(result.stdout);

--- a/lib/Vendor.js
+++ b/lib/Vendor.js
@@ -126,7 +126,7 @@ function buildWithScript(platform, sourcePath, outPath, script, deps) {
     process.env["VENDOR_BUILD_TYPE"] = buildType;
     process.env["VENDOR_OUT_DIR"] = outPath;
     Utils.log("cwd: " + sourcePath)
-    Utils.exec(cmd, sourcePath, platform.verbose);
+    Utils.exec(cmd, sourcePath, platform.verbose, undefined, platform.archs);
 }
 
 function hasVendorHashFile(filePath) {


### PR DESCRIPTION
buildWithScript方法中传递arch参数给自定义脚本。在macOS+M系列芯片中可以编译x64 arm64的第三方库，有此参数就可以按需编译，提高效率