### PR TITLE
feat: Apple 平台构建xcframework时增加头文件设置

### DIFF
--- a/lib-build
+++ b/lib-build
@@ -53,6 +53,11 @@ const optionDeclarations = [
         description: "Merges all arches of the output libraries into one xcframework if the current platform supports it."
     },
     {
+        name: "headers",
+        type: "string",
+        description: "Only valid when xcframework is enabled. Defaults is [source]/include."
+    },
+    {
         name: "native",
         shortName: "n",
         type: "boolean",
@@ -209,6 +214,11 @@ if (!options.source) {
 } else {
     options.source = path.resolve(options.source);
 }
+
+if ((!options.headers || options.headers.length == 0) && (options.xcframework || false)) {
+    options.headers = path.join(options.source, "include");
+}
+
 if ((!options.targets || options.targets.length === 0) && isCustomBuild) {
     let basename = path.basename(process.argv[1]);
     let target = "";
@@ -290,7 +300,8 @@ function performBuild(targetName, buildType, platform, options, cmakeArgs, libra
             startMessage = "";
         }
         currentXCHash = versionHash;
-        libraryTool.createXCFramework(options.output, options.output, false, function (library) {
+        let headerPath = path.resolve(options.headers);
+        libraryTool.createXCFramework(options.output, headerPath, options.output, false, function (library) {
             let ext = path.extname(library);
             let name = path.parse(library).name;
             return ext && name.indexOf(targetName) !== -1;

--- a/lib-merge
+++ b/lib-merge
@@ -18,6 +18,11 @@ const optionDeclarations = [
         description: "Merges all archs in the specified library path into one xcframework if current platform supports it."
     },
     {
+        name: "headers",
+        type: "string",
+        description: "Only valid when xcframework is enabled. Defaults is [source]/include."
+    },
+    {
         name: "arch",
         shortName: "a",
         type: "string",
@@ -61,6 +66,11 @@ if (options.help) {
     }
     return;
 }
+
+if ((!options.headers || options.headers.length == 0) && (options.xcframework || false)) {
+    options.headers = path.join(options.source, "include");
+}
+
 let platform = Platform.Create(options.platform, false, options.verbose);
 if (!options.arch) {
     options.arch = platform.archs[0];
@@ -76,7 +86,8 @@ if (options.xcframework) {
         outputPath = path.resolve(options.output, platform.name);
         removeOrigins = false;
     }
-    libraryTool.createXCFramework(libraryPath, outputPath, removeOrigins);
+    let headerPath = path.resolve(options.headers);
+    libraryTool.createXCFramework(libraryPath, headerPath, outputPath, removeOrigins);
 } else {
     libraryTool.mergeLibraries(options.targets, options.output, options.arch);
 }

--- a/lib/LibraryTool.js
+++ b/lib/LibraryTool.js
@@ -109,7 +109,7 @@ class LibraryTool {
     mergeLibraries(libraries, output, arch) {
     }
 
-    createXCFramework(libraryPath, outPath, removeOrigins, filter) {
+    createXCFramework(libraryPath, headerPath, outPath, removeOrigins, filter) {
         return false;
     }
 }
@@ -281,7 +281,7 @@ class AppleLibraryTool extends LibraryTool {
         return true;
     }
 
-    createXCFramework(libraryPath, outPath, removeOrigins, filter) {
+    createXCFramework(libraryPath, headerPath, outPath, removeOrigins, filter) {
         if (!outPath) {
             outPath = libraryPath;
         }
@@ -320,6 +320,9 @@ class AppleLibraryTool extends LibraryTool {
             let libraryInput = "";
             for (let fatLibrary of fatLibraries) {
                 libraryInput += commandKey + Utils.escapeSpace(fatLibrary);
+                if (!isFramework && !!headerPath) {
+                    libraryInput += " -headers " + Utils.escapeSpace(headerPath);
+                }
             }
             let outputFile = path.join(outPath, libraryName + ".xcframework");
             let symbolPath = path.join(outPath, libraryName + ".dSYMs");

--- a/lib/Vendor.js
+++ b/lib/Vendor.js
@@ -178,7 +178,7 @@ class Vendor {
         this.vendors = parseVendors(data, projectPath, this.platform);
     }
 
-    buildAll(vendorNames, outPath, xcframework) {
+    buildAll(vendorNames, headerPath, outPath, xcframework) {
         if (!Array.isArray(vendorNames) || vendorNames.length === 0) {
             vendorNames = Object.keys(this.vendors);
         }
@@ -230,7 +230,7 @@ class Vendor {
                 return;
             }
             Utils.log("Publishing vendor libraries: [" + vendorNames.join(",") + "] into " + outPath);
-            this.publishLibraries(libraryPaths, outPath, archs, xcframework);
+            this.publishLibraries(libraryPaths, headerPath, outPath, archs, xcframework);
             for (let arch of archs) {
                 let hashFile = path.join(outPath, "." + arch + ".md5");
                 Utils.writeFile(hashFile, hashTable[arch]);
@@ -323,7 +323,7 @@ class Vendor {
         }
     }
 
-    publishLibraries(libraryPaths, outPath, archs, xcframework) {
+    publishLibraries(libraryPaths, headerPath, outPath, archs, xcframework) {
         let libraryTool = LibraryTool.Create(this.platform);
         for (let arch of archs) {
             let libraries = [];
@@ -347,9 +347,9 @@ class Vendor {
             }
         }
         if (xcframework) {
-            libraryTool.createXCFramework(outPath, outPath, false);
+            libraryTool.createXCFramework(outPath, headerPath, outPath, false);
             for (let libraryPath of libraryPaths) {
-                libraryTool.createXCFramework(libraryPath, outPath, false, function (library) {
+                libraryTool.createXCFramework(libraryPath, headerPath, outPath, false, function (library) {
                     return !LibraryTool.IsStaticLibrary(library);
                 });
             }

--- a/vendor-build
+++ b/vendor-build
@@ -36,6 +36,11 @@ const optionDeclarations = [
         description: "Merges all arches of the output libraries into one xcframework if current platform supports it. Ignored if --output is not specified."
     },
     {
+        name: "headers",
+        type: "string",
+        description: "Only valid when xcframework is enabled. Defaults is [source]/include."
+    },
+    {
         name: "debug",
         shortName: "d",
         type: "boolean",
@@ -83,6 +88,11 @@ if (!options.debug) {
 if (options.xcframework) {
     delete options.arch;
 }
+
+if ((!options.headers || options.headers.length == 0) && (options.xcframework || false)) {
+    options.headers = path.join(options.source, "include");
+}
+
 let execPath = path.resolve(process.argv[1]);
 let isCustomBuild = execPath !== __filename;
 if (!options.source) {
@@ -98,5 +108,6 @@ let platform = Platform.Create(options.platform, options.debug, options.verbose)
 if (options.arch) {
     platform.archs = [options.arch.toLowerCase()];
 }
+let headerPath = path.resolve(options.headers);
 let vendor = new Vendor(configFile, platform);
-vendor.buildAll(options.targets, options.output, options.xcframework);
+vendor.buildAll(options.targets, headerPath, options.output, options.xcframework);


### PR DESCRIPTION
* Apple 平台构建启用 xcframework 同时库又是 .a 时未设置头文件
* 例如在 tgfx 中构建时缺少头文件，需要手动拷贝到工程中
```bash
node build_tgfx --incremental -p ios --xcframework
```
* 增加`--headers`参数支持
```bash
node build_tgfx --incremental -p ios --xcframework --headers ./include
```