### PR TITLE
Bump macOS ARM64 and Universal minimum deployment target from 11.0 to 12.0

### DIFF
--- a/ios.toolchain.cmake
+++ b/ios.toolchain.cmake
@@ -266,11 +266,11 @@ if(NOT DEFINED DEPLOYMENT_TARGET)
     # Unless specified, SDK version 1.0 is used by default as minimum target version (visionOS).
     set(DEPLOYMENT_TARGET "1.0")
   elseif(PLATFORM STREQUAL "MAC_ARM64")
-    # Unless specified, SDK version 11.0 (Big Sur) is used by default as the minimum target version (macOS on arm).
-    set(DEPLOYMENT_TARGET "11.0")
+    # Unless specified, SDK version 12.0 (Monterey) is used by default as the minimum target version (macOS on arm).
+    set(DEPLOYMENT_TARGET "12.0")
   elseif(PLATFORM STREQUAL "MAC_UNIVERSAL")
-    # Unless specified, SDK version 11.0 (Big Sur) is used by default as minimum target version for universal builds.
-    set(DEPLOYMENT_TARGET "11.0")
+    # Unless specified, SDK version 12.0 (Monterey) is used by default as minimum target version for universal builds.
+    set(DEPLOYMENT_TARGET "12.0")
   elseif(PLATFORM STREQUAL "MAC_CATALYST" OR PLATFORM STREQUAL "MAC_CATALYST_ARM64")
     # Unless specified, SDK version 13.0 is used by default as the minimum target version (mac catalyst minimum requirement).
     set(DEPLOYMENT_TARGET "13.1")


### PR DESCRIPTION
将 macOS ARM64 (MAC_ARM64) 和 Universal (MAC_UNIVERSAL) 构建的最低部署目标版本从 11.0 (Big Sur) 提升到 12.0 (Monterey)。