### PR TITLE
Revert macOS ARM64 and Universal minimum deployment target back to 11.0

### DIFF
--- a/ios.toolchain.cmake
+++ b/ios.toolchain.cmake
@@ -266,11 +266,11 @@ if(NOT DEFINED DEPLOYMENT_TARGET)
     # Unless specified, SDK version 1.0 is used by default as minimum target version (visionOS).
     set(DEPLOYMENT_TARGET "1.0")
   elseif(PLATFORM STREQUAL "MAC_ARM64")
-    # Unless specified, SDK version 12.0 (Monterey) is used by default as the minimum target version (macOS on arm).
-    set(DEPLOYMENT_TARGET "12.0")
+    # Unless specified, SDK version 11.0 (Big Sur) is used by default as the minimum target version (macOS on arm).
+    set(DEPLOYMENT_TARGET "11.0")
   elseif(PLATFORM STREQUAL "MAC_UNIVERSAL")
-    # Unless specified, SDK version 12.0 (Monterey) is used by default as minimum target version for universal builds.
-    set(DEPLOYMENT_TARGET "12.0")
+    # Unless specified, SDK version 11.0 (Big Sur) is used by default as minimum target version for universal builds.
+    set(DEPLOYMENT_TARGET "11.0")
   elseif(PLATFORM STREQUAL "MAC_CATALYST" OR PLATFORM STREQUAL "MAC_CATALYST_ARM64")
     # Unless specified, SDK version 13.0 is used by default as the minimum target version (mac catalyst minimum requirement).
     set(DEPLOYMENT_TARGET "13.1")


### PR DESCRIPTION
## Summary
- Reverts #31 which bumped macOS ARM64 and Universal minimum deployment target from 11.0 to 12.0
- Restores the default deployment target to 11.0 (Big Sur) for MAC_ARM64 and MAC_UNIVERSAL platforms

## Test plan
- [ ] Verify macOS ARM64 build with deployment target 11.0
- [ ] Verify macOS Universal build with deployment target 11.0